### PR TITLE
Added containers for CUDA 13.0 and 13.2

### DIFF
--- a/.github/workflows/deploy-docker-manylinux_2_28_x86_64_cuda_13.0.yml
+++ b/.github/workflows/deploy-docker-manylinux_2_28_x86_64_cuda_13.0.yml
@@ -1,0 +1,57 @@
+name: deploy-docker-manylinux_2_28_x86_64_cuda_13.0
+
+on:
+    push:
+        branches:
+            - main
+    release:
+        types: 
+            - published
+
+jobs:
+  build_docker:
+        name: build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v5
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push manylinux_2_28_x86_64_cuda-13.0
+              id: docker_build
+              uses: docker/build-push-action@v6
+              with:
+                  push: true
+                  file: ./docker/manylinux_2_28_x86_64_cuda_13.0/Dockerfile
+                  tags: sameli/manylinux_2_28_x86_64_cuda_13.0:latest
+
+            - name: Image digest
+              run: echo ${{ steps.docker_build.outputs.digest }}
+
+  test_docker:
+        needs: [build_docker]
+        name: test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Install Snap
+              run: |
+                sudo apt update
+                sudo apt install snapd
+
+            - name: Install Docker
+              run: |
+                sudo snap install docker
+                sudo groupadd -f docker
+                sudo usermod -aG docker $USER
+                newgrp docker
+
+            - name: Pull Docker Image
+              run: docker pull sameli/manylinux_2_28_x86_64_cuda_13.0
+
+            - name: Run Docker Image
+              run: docker run -t sameli/manylinux_2_28_x86_64_cuda_13.0 nvcc --version

--- a/.github/workflows/deploy-docker-manylinux_2_28_x86_64_cuda_13.2.yml
+++ b/.github/workflows/deploy-docker-manylinux_2_28_x86_64_cuda_13.2.yml
@@ -1,0 +1,57 @@
+name: deploy-docker-manylinux_2_28_x86_64_cuda_13.2
+
+on:
+    push:
+        branches:
+            - main
+    release:
+        types: 
+            - published
+
+jobs:
+  build_docker:
+        name: build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v5
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push manylinux_2_28_x86_64_cuda-13.2
+              id: docker_build
+              uses: docker/build-push-action@v6
+              with:
+                  push: true
+                  file: ./docker/manylinux_2_28_x86_64_cuda_13.2/Dockerfile
+                  tags: sameli/manylinux_2_28_x86_64_cuda_13.2:latest
+
+            - name: Image digest
+              run: echo ${{ steps.docker_build.outputs.digest }}
+
+  test_docker:
+        needs: [build_docker]
+        name: test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Install Snap
+              run: |
+                sudo apt update
+                sudo apt install snapd
+
+            - name: Install Docker
+              run: |
+                sudo snap install docker
+                sudo groupadd -f docker
+                sudo usermod -aG docker $USER
+                newgrp docker
+
+            - name: Pull Docker Image
+              run: docker pull sameli/manylinux_2_28_x86_64_cuda_13.2
+
+            - name: Run Docker Image
+              run: docker run -t sameli/manylinux_2_28_x86_64_cuda_13.2 nvcc --version

--- a/.github/workflows/deploy-docker-manylinux_2_34_x86_64_cuda_13.0.yml
+++ b/.github/workflows/deploy-docker-manylinux_2_34_x86_64_cuda_13.0.yml
@@ -1,0 +1,57 @@
+name: deploy-docker-manylinux_2_34_x86_64_cuda_13.0
+
+on:
+    push:
+        branches:
+            - main
+    release:
+        types: 
+            - published
+
+jobs:
+  build_docker:
+        name: build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v5
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push manylinux_2_34_x86_64_cuda-13.0
+              id: docker_build
+              uses: docker/build-push-action@v6
+              with:
+                  push: true
+                  file: ./docker/manylinux_2_34_x86_64_cuda_13.0/Dockerfile
+                  tags: sameli/manylinux_2_34_x86_64_cuda_13.0:latest
+
+            - name: Image digest
+              run: echo ${{ steps.docker_build.outputs.digest }}
+
+  test_docker:
+        needs: [build_docker]
+        name: test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Install Snap
+              run: |
+                sudo apt update
+                sudo apt install snapd
+
+            - name: Install Docker
+              run: |
+                sudo snap install docker
+                sudo groupadd -f docker
+                sudo usermod -aG docker $USER
+                newgrp docker
+
+            - name: Pull Docker Image
+              run: docker pull sameli/manylinux_2_34_x86_64_cuda_13.0
+
+            - name: Run Docker Image
+              run: docker run -t sameli/manylinux_2_34_x86_64_cuda_13.0 nvcc --version

--- a/.github/workflows/deploy-docker-manylinux_2_34_x86_64_cuda_13.2.yml
+++ b/.github/workflows/deploy-docker-manylinux_2_34_x86_64_cuda_13.2.yml
@@ -1,0 +1,57 @@
+name: deploy-docker-manylinux_2_34_x86_64_cuda_13.2
+
+on:
+    push:
+        branches:
+            - main
+    release:
+        types: 
+            - published
+
+jobs:
+  build_docker:
+        name: build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v5
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push manylinux_2_34_x86_64_cuda-13.2
+              id: docker_build
+              uses: docker/build-push-action@v6
+              with:
+                  push: true
+                  file: ./docker/manylinux_2_34_x86_64_cuda_13.2/Dockerfile
+                  tags: sameli/manylinux_2_34_x86_64_cuda_13.2:latest
+
+            - name: Image digest
+              run: echo ${{ steps.docker_build.outputs.digest }}
+
+  test_docker:
+        needs: [build_docker]
+        name: test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Install Snap
+              run: |
+                sudo apt update
+                sudo apt install snapd
+
+            - name: Install Docker
+              run: |
+                sudo snap install docker
+                sudo groupadd -f docker
+                sudo usermod -aG docker $USER
+                newgrp docker
+
+            - name: Pull Docker Image
+              run: docker pull sameli/manylinux_2_34_x86_64_cuda_13.2
+
+            - name: Run Docker Image
+              run: docker run -t sameli/manylinux_2_34_x86_64_cuda_13.2 nvcc --version

--- a/docker-compose-x86_64.yml
+++ b/docker-compose-x86_64.yml
@@ -20,6 +20,14 @@ services:
         build: ./docker/manylinux_2_28_x86_64_cuda_12.3
         image: sameli/manylinux_2_28_x86_64_cuda_12.3
 
+    manylinux_2_28_x86_64_cuda_13.0:
+        build: ./docker/manylinux_2_28_x86_64_cuda_13.0
+        image: sameli/manylinux_2_28_x86_64_cuda_13.0
+
+    manylinux_2_28_x86_64_cuda_13.2:
+        build: ./docker/manylinux_2_28_x86_64_cuda_13.2
+        image: sameli/manylinux_2_28_x86_64_cuda_13.2
+
     manylinux_2_34_x86_64_cuda_12.8:
         build: ./docker/manylinux_2_34_x86_64_cuda_12.8
         image: sameli/manylinux_2_34_x86_64_cuda_12.8
@@ -27,3 +35,11 @@ services:
     manylinux_2_34_x86_64_cuda_12.9:
         build: ./docker/manylinux_2_34_x86_64_cuda_12.9
         image: sameli/manylinux_2_34_x86_64_cuda_12.9
+
+    manylinux_2_34_x86_64_cuda_13.0:
+        build: ./docker/manylinux_2_34_x86_64_cuda_13.0
+        image: sameli/manylinux_2_34_x86_64_cuda_13.0
+
+    manylinux_2_34_x86_64_cuda_13.2:
+        build: ./docker/manylinux_2_34_x86_64_cuda_13.2
+        image: sameli/manylinux_2_34_x86_64_cuda_13.2

--- a/docker/manylinux_2_28_x86_64_cuda_13.0/Dockerfile
+++ b/docker/manylinux_2_28_x86_64_cuda_13.0/Dockerfile
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright 2026, Mason Davy <masonnosam11@gmail.com>
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileType: SOURCE
+
+# -----------------------------------------------------------------------------
+# How to build
+#   $ docker build -t sameli/manylinux_2_28_x86_64_cuda_13.0 -f <This-Filename> .
+#
+# How to run:
+#   $ docker run -it -v/host_dir:/image_dir --entrypoint /bin/bash \
+#         manylinux_2_28_x86_64_cuda_13.0
+# -----------------------------------------------------------------------------
+
+# -----------------
+# Choose base image
+# -----------------
+
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+MAINTAINER Siavash Ameli <samei@berkeley.edu>
+LABEL Description="manylinux_2_28_x86_64 with cuda 13.0"
+
+# ------------
+# Install cuda
+# ------------
+
+ARG VER="13-0"
+ARG ARCH="x86_64"
+
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+RUN dnf -y install cuda-compiler-${VER}.${ARCH} \
+                   cuda-libraries-${VER}.${ARCH} \
+                   cuda-libraries-devel-${VER}.${ARCH}
+RUN dnf clean all
+RUN rm -rf /var/cache/dnf/*
+RUN echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/999_nvidia_cuda.conf
+
+# -------------------------
+# Set environment variables
+# -------------------------
+
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_ROOT=/usr/local/cuda
+ENV CUDA_PATH=/usr/local/cuda
+ENV CUDADIR=/usr/local/cuda
+
+# --------
+# Commands
+# --------
+
+CMD ["/bin/bash"]

--- a/docker/manylinux_2_28_x86_64_cuda_13.2/Dockerfile
+++ b/docker/manylinux_2_28_x86_64_cuda_13.2/Dockerfile
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright 2026, Mason Davy <masonnosam11@gmail.com>
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileType: SOURCE
+
+# -----------------------------------------------------------------------------
+# How to build
+#   $ docker build -t sameli/manylinux_2_28_x86_64_cuda_13.0 -f <This-Filename> .
+#
+# How to run:
+#   $ docker run -it -v/host_dir:/image_dir --entrypoint /bin/bash \
+#         manylinux_2_28_x86_64_cuda_13.0
+# -----------------------------------------------------------------------------
+
+# -----------------
+# Choose base image
+# -----------------
+
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+MAINTAINER Siavash Ameli <samei@berkeley.edu>
+LABEL Description="manylinux_2_28_x86_64 with cuda 13.2"
+
+# ------------
+# Install cuda
+# ------------
+
+ARG VER="13-2"
+ARG ARCH="x86_64"
+
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+RUN dnf -y install cuda-compiler-${VER}.${ARCH} \
+                   cuda-libraries-${VER}.${ARCH} \
+                   cuda-libraries-devel-${VER}.${ARCH}
+RUN dnf clean all
+RUN rm -rf /var/cache/dnf/*
+RUN echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/999_nvidia_cuda.conf
+
+# -------------------------
+# Set environment variables
+# -------------------------
+
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_ROOT=/usr/local/cuda
+ENV CUDA_PATH=/usr/local/cuda
+ENV CUDADIR=/usr/local/cuda
+
+# --------
+# Commands
+# --------
+
+CMD ["/bin/bash"]

--- a/docker/manylinux_2_34_x86_64_cuda_13.0/Dockerfile
+++ b/docker/manylinux_2_34_x86_64_cuda_13.0/Dockerfile
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright 2026, Mason Davy <masonnosam11@gmail.com>
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileType: SOURCE
+
+# -----------------------------------------------------------------------------
+# How to build
+#   $ docker build -t sameli/manylinux_2_34_x86_64_cuda_13.0 -f <This-Filename> .
+#
+# How to run:
+#   $ docker run -it -v/host_dir:/image_dir --entrypoint /bin/bash \
+#         manylinux_2_34_x86_64_cuda_13.0
+# -----------------------------------------------------------------------------
+
+# -----------------
+# Choose base image
+# -----------------
+
+FROM quay.io/pypa/manylinux_2_34_x86_64
+
+MAINTAINER Siavash Ameli <samei@berkeley.edu>
+LABEL Description="manylinux_2_34_x86_64 with cuda 13.0"
+
+# ------------
+# Install cuda
+# ------------
+
+ARG VER="13-0"
+ARG ARCH="x86_64"
+
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
+RUN dnf -y install cuda-compiler-${VER}.${ARCH} \
+                   cuda-libraries-${VER}.${ARCH} \
+                   cuda-libraries-devel-${VER}.${ARCH}
+RUN dnf clean all
+RUN rm -rf /var/cache/dnf/*
+RUN echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/999_nvidia_cuda.conf
+
+# -------------------------
+# Set environment variables
+# -------------------------
+
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_ROOT=/usr/local/cuda
+ENV CUDA_PATH=/usr/local/cuda
+ENV CUDADIR=/usr/local/cuda
+
+# --------
+# Commands
+# --------
+
+CMD ["/bin/bash"]

--- a/docker/manylinux_2_34_x86_64_cuda_13.2/Dockerfile
+++ b/docker/manylinux_2_34_x86_64_cuda_13.2/Dockerfile
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright 2026, Mason Davy <masonnosam11@gmail.com>
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileType: SOURCE
+
+# -----------------------------------------------------------------------------
+# How to build
+#   $ docker build -t sameli/manylinux_2_34_x86_64_cuda_13.2 -f <This-Filename> .
+#
+# How to run:
+#   $ docker run -it -v/host_dir:/image_dir --entrypoint /bin/bash \
+#         manylinux_2_34_x86_64_cuda_13.2
+# -----------------------------------------------------------------------------
+
+# -----------------
+# Choose base image
+# -----------------
+
+FROM quay.io/pypa/manylinux_2_34_x86_64
+
+MAINTAINER Siavash Ameli <samei@berkeley.edu>
+LABEL Description="manylinux_2_34_x86_64 with cuda 13.2"
+
+# ------------
+# Install cuda
+# ------------
+
+ARG VER="13-2"
+ARG ARCH="x86_64"
+
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
+RUN dnf -y install cuda-compiler-${VER}.${ARCH} \
+                   cuda-libraries-${VER}.${ARCH} \
+                   cuda-libraries-devel-${VER}.${ARCH}
+RUN dnf clean all
+RUN rm -rf /var/cache/dnf/*
+RUN echo "/usr/local/cuda/lib64" >> /etc/ld.so.conf.d/999_nvidia_cuda.conf
+
+# -------------------------
+# Set environment variables
+# -------------------------
+
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_ROOT=/usr/local/cuda
+ENV CUDA_PATH=/usr/local/cuda
+ENV CUDADIR=/usr/local/cuda
+
+# --------
+# Commands
+# --------
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
These containers are for both manylinux 2.28 and 2.34.

A few of the projects that I'm working on would benefit from having these for newer versions of CUDA. I've updated the dockfiles to contain copyright info specific to me, though I'll happily change it to the maintainer if desired.